### PR TITLE
chore: `repository-initialize-command` isn't required

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5983,7 +5983,7 @@ async function run() {
       throw new Error(`Event ${import_github2.context.eventName} is not supported.`);
     }
     await checkPermission();
-    const repositoryInitializeCommand = core3.getInput("repository-initialize-command", {required: true});
+    const repositoryInitializeCommand = core3.getInput("repository-initialize-command");
     const usersEslintRemoteTesterConfig = core3.getInput("eslint-remote-tester-config", {required: true});
     const {
       maxResultCount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,7 @@ async function run() {
 
         await checkPermission();
 
-        const repositoryInitializeCommand = core.getInput(
-            'repository-initialize-command',
-            { required: true }
-        );
+        const repositoryInitializeCommand = core.getInput('repository-initialize-command');
         const usersEslintRemoteTesterConfig = core.getInput(
             'eslint-remote-tester-config',
             { required: true }


### PR DESCRIPTION
https://github.com/AriPerkkio/eslint-remote-tester-compare-action/blob/41be25e0be0a81035c45ad5df6351796b9eb6b32/action.yml#L17-L20