### PR TITLE
chore: `eslint-remote-tester-config` isn't required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   eslint-remote-tester-config:
     description: 'Path to eslint-remote-tester.config.js'
-    reqired: false
+    required: false
     default: 'eslint-remote-tester.config.js'
   github-token:
     description: 'GitHub token'

--- a/dist/index.js
+++ b/dist/index.js
@@ -5984,7 +5984,7 @@ async function run() {
     }
     await checkPermission();
     const repositoryInitializeCommand = core3.getInput("repository-initialize-command");
-    const usersEslintRemoteTesterConfig = core3.getInput("eslint-remote-tester-config", {required: true});
+    const usersEslintRemoteTesterConfig = core3.getInput("eslint-remote-tester-config");
     const {
       maxResultCount,
       ...configurationFromComment

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,11 @@ async function run() {
 
         await checkPermission();
 
-        const repositoryInitializeCommand = core.getInput('repository-initialize-command');
+        const repositoryInitializeCommand = core.getInput(
+            'repository-initialize-command'
+        );
         const usersEslintRemoteTesterConfig = core.getInput(
-            'eslint-remote-tester-config',
-            { required: true }
+            'eslint-remote-tester-config'
         );
 
         const {


### PR DESCRIPTION
https://github.com/AriPerkkio/eslint-remote-tester-compare-action/blob/41be25e0be0a81035c45ad5df6351796b9eb6b32/action.yml#L10-L13