### PR TITLE
chore: `allowed-associations` isn't required

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6051,9 +6051,7 @@ async function checkPermission() {
   if (permission !== "admin" && permission !== "write") {
     throw new Error(`${import_github2.context.actor} does not have admin/write permission. Found permission: ${permission}`);
   }
-  const allowedAssociations = core3.getInput("allowed-associations", {
-    required: true
-  });
+  const allowedAssociations = core3.getInput("allowed-associations");
   let allowed;
   try {
     allowed = JSON.parse(allowedAssociations);

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,9 +188,7 @@ async function checkPermission() {
         );
     }
 
-    const allowedAssociations = core.getInput('allowed-associations', {
-        required: true,
-    });
+    const allowedAssociations = core.getInput('allowed-associations');
 
     let allowed: string[];
     try {


### PR DESCRIPTION
https://github.com/AriPerkkio/eslint-remote-tester-compare-action/blob/41be25e0be0a81035c45ad5df6351796b9eb6b32/action.yml#L21-L24